### PR TITLE
Fix(typo): Remove the comma after browser in environments section of documentation

### DIFF
--- a/site/docs/guide/index.mdx
+++ b/site/docs/guide/index.mdx
@@ -18,7 +18,7 @@ You can learn more about the inspiration behind the project in the [Why Lovit](/
 
 ## Environments
 
-You can run Lovit in the browser, or in Node.js. Lovit requires Node.js version 18 or above. Both ESM and CommonJS imports are available.
+You can run Lovit in the browser or in Node.js. Lovit requires Node.js version 18 or above. Both ESM and CommonJS imports are available.
 
 ## Concepts
 


### PR DESCRIPTION
### Summary

Fixed a typo mistake by removing the comma after 'browser' in environments section of documentation.

### Motivation

Typos need to be addressed.

### Change Type

- [ ] 🐞 Bug fix (non-breaking fix for an issue)
- [ ] ✨ Feature (non-breaking addition)
- [x] 🧹 Refactor (non-breaking improvements, no behavior change)
- [ ] 💥 Breaking change (fix or feature that would change existing functionality)

Before: 
<img width="680" alt="image" src="https://github.com/user-attachments/assets/8b3d7827-26c9-4166-a861-4ec847b58c5e" />
After:
<img width="718" alt="SCR-20250519-bhwe" src="https://github.com/user-attachments/assets/d2bd2ead-f0bd-44c3-aa56-af57b4ad35f4" />


### Checklist

<!-- Make sure to complete these before requesting a review -->

- [x] I’ve read the [Contributing Guidelines](https://github.com/lovit-dev/lovit/blob/main/.github/CONTRIBUTING.md)
- [x] My code matches the project’s coding style (`npm run lint`)
- [x] My change introduces changes to the documentation
- [x] I’ve updated documentation where needed
- [ ] I’ve added tests covering new behavior
- [x] All existing and new tests pass

### Related Issues

- Closes #1  
