### PR TITLE
fix(typo): Change the Spelling "Github" to "GitHub" in Community section of `Getting Started` page

### DIFF
--- a/site/docs/guide/index.mdx
+++ b/site/docs/guide/index.mdx
@@ -62,4 +62,4 @@ Once you're familiar with the core ideas, you can move on to the [Usage section]
 
 ## Community
 
-If you have questions or need help, reach out to the community via [Discord](https://discord.gg/3sBv9mUF) and [Github Discussion](https://github.com/lovit-dev/lovit/discussions).
+If you have questions or need help, reach out to the community via [Discord](https://discord.gg/3sBv9mUF) and [GitHub Discussion](https://github.com/lovit-dev/lovit/discussions).


### PR DESCRIPTION
### Summary

Correct the Spelling "Github" to "GitHub" in Community section of `Getting Started` page as mentioned in issue #2 

### Motivation

Typo Mistake

### Change Type


- [ ] 🐞 Bug fix (non-breaking fix for an issue)
- [ ] ✨ Feature (non-breaking addition)
- [x] 🧹 Refactor (non-breaking improvements, no behavior change)
- [ ] 💥 Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Make sure to complete these before requesting a review -->

- [x] I’ve read the [Contributing Guidelines](https://github.com/lovit-dev/lovit/blob/main/.github/CONTRIBUTING.md)
- [x] My code matches the project’s coding style (`npm run lint`)
- [x] My change introduces changes to the documentation
- [x] I’ve updated documentation where needed
- [ ] I’ve added tests covering new behavior
- [x] All existing and new tests pass

### Related Issues
Issue: #2 