### PR TITLE
fix(docs): update expired Discord invite link

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,7 +10,7 @@ If you want to work on the demo, check the README in the `demo` folder.
 
 To help keep things organized, we use the [issue tracker](https://github.com/lovit-dev/lovit/issues) for tracking **bugs**, requesting **features**, and managing **pull requests**. Please follow these simple rules:
 
-- **No support requests**: The issue tracker isn't for personal troubleshooting. For help, join our [`Discord server`](https://discord.gg/3sBv9mUF) or use [`GitHub Discussions`](https://github.com/lovit-dev/lovit/discussions).
+- **No support requests**: The issue tracker isn't for personal troubleshooting. For help, join our [`Discord server`](https://discord.gg/kkx5zYKZwR) or use [`GitHub Discussions`](https://github.com/lovit-dev/lovit/discussions).
 
 - **Avoid duplicates**: Before opening a new issue, please [search](https://github.com/lovit-dev/lovit/issues?utf8=%E2%9C%93&q=is%3Aissue) to see if it’s already been reported.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ a project may be further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by [contacting a Moderator or Maintainer via Discord](https://discord.gg/3sBv9mUF). All
+reported by [contacting a Moderator or Maintainer via Discord](https://discord.gg/kkx5zYKZwR). All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For support, sharing best practices, or any discussions you'd like to keep for r
 
 For chatting with others:
 
-[Join the Lovit Discord Server](https://discord.gg/3sBv9mUF)
+[Join the Lovit Discord Server](https://discord.gg/kkx5zYKZwR)
 
 ## Contributing
 

--- a/site/docs/guide/index.mdx
+++ b/site/docs/guide/index.mdx
@@ -62,4 +62,4 @@ Once you're familiar with the core ideas, you can move on to the [Usage section]
 
 ## Community
 
-If you have questions or need help, reach out to the community via [Discord](https://discord.gg/3sBv9mUF) and [GitHub Discussion](https://github.com/lovit-dev/lovit/discussions).
+If you have questions or need help, reach out to the community via [Discord](https://discord.gg/kkx5zYKZwR) and [GitHub Discussion](https://github.com/lovit-dev/lovit/discussions).

--- a/site/src/constants.ts
+++ b/site/src/constants.ts
@@ -23,6 +23,6 @@ export enum ApiPath {
 
 export enum SocialLinks {
   X = 'https://x.com/lovit_js',
-  Discord = 'https://discord.gg/3sBv9mUF',
+  Discord = 'https://discord.gg/kkx5zYKZwR',
   Github = 'https://github.com/lovit-dev/lovit'
 }


### PR DESCRIPTION
### Summary

This pull request updates the expired Discord invite link across multiple documentation files to ensure new users can join the community. The old link (`https://discord.com/invite/3sBv9mUF`) was replaced with the new, non-expiring link (`https://discord.gg/kkx5zYKZwR`) in the following files:
- `README.md`
- `site/src/constants.ts`
- `site/docs/guide/index.mdx`
- `CODE_OF_CONDUCT.md`
- `CONTRIBUTING.md`

### Motivation

The current Discord invite link is expired, preventing new users from joining the `lovit-dev/lovit` community. This change fixes the issue by updating the link to a valid, non-expiring one, as reported in issue #11. This ensures seamless access to the community for collaboration and support.

### Change Type

- [x] 🐞 Bug fix (non-breaking fix for an issue)
- [ ] ✨ Feature (non-breaking addition)
- [ ] 🧹 Refactor (non-breaking improvements, no behavior change)
- [ ] 💥 Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I’ve read the [Contributing Guidelines](https://github.com/lovit-dev/lovit/blob/main/.github/CONTRIBUTING.md)
- [x] My code matches the project’s coding style (`npm run lint`)
- [x] My change introduces changes to the documentation
- [x] I’ve updated documentation where needed
- [ ] I’ve added tests covering new behavior
- [x] All existing and new tests pass

### Related Issues

- Closes #11 