### PR TITLE
fix: aria-label attr and add noreferrer in anchor rel attr

### DIFF
--- a/site/src/components/Header.tsx
+++ b/site/src/components/Header.tsx
@@ -93,6 +93,7 @@ export default function Header() {
           <button
             aria-expanded={open}
             aria-controls='mobile-menu'
+            aria-label='Toggle menu'
             onClick={() => setOpen(!open)}
             className='block py-3 text-xl text-grey lg:hidden'
           >
@@ -107,7 +108,7 @@ export default function Header() {
 function SocialLink({ icon: Icon, href }: { icon: IconType; href: string }) {
   return (
     <li>
-      <a href={href} target='_blank' rel='noopener'>
+      <a href={href} target='_blank' rel='noreferrer noopener'>
         <Icon className='text-xl text-grey transition-colors duration-250 hover:text-grey-light' />
       </a>
     </li>

--- a/site/src/components/LinkButton.tsx
+++ b/site/src/components/LinkButton.tsx
@@ -8,7 +8,7 @@ function LinkButton({ variant, to, className, ...props }: VariantProps<typeof va
   const classes = cn(variants({ variant, className }));
 
   if (isExternal) {
-    return <a href={to} className={classes} target='_blank' rel='noopener' {...props} />;
+    return <a href={to} className={classes} target='_blank' rel='noreferrer noopener' {...props} />;
   }
 
   return <Link to={to} className={classes} {...props} />;

--- a/site/src/components/mdx/DocLink.tsx
+++ b/site/src/components/mdx/DocLink.tsx
@@ -7,7 +7,7 @@ function DocLink({ children, href }: { children: string; href: string }) {
 
   if (isExternal) {
     return (
-      <a className={className} href={href} target='_blank' rel='noopener'>
+      <a className={className} href={href} target='_blank' rel='noreferrer noopener'>
         {children}
       </a>
     );


### PR DESCRIPTION
### Summary

<!-- Provide a clear and detailed explanation of what this pull request changes -->
Added `aria-label` attribute to mobile menu button for screen readers.
Include `noreferrer` to anchor tags `rel` attribute with target `_blank` for old browser support.

### Motivation

<!-- Why is this change necessary? What problem does it solve? -->
When the link is opened in a new tab, the referrer information is sent in the referer header and some sensitive data may be exposed in the url to the target site. `noreferrer` option alone is enough for modern browsers, but including both works perfectly for some old browsers.

### Change Type

<!-- Indicate the type of changes this pull request introduces. Select all that apply by marking the boxes with an `x`. -->

- [X] 🐞 Bug fix (non-breaking fix for an issue)
- [ ] ✨ Feature (non-breaking addition)
- [ ] 🧹 Refactor (non-breaking improvements, no behavior change)
- [ ] 💥 Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Make sure to complete these before requesting a review -->

- [X] I’ve read the [Contributing Guidelines](https://github.com/lovit-dev/lovit/blob/main/.github/CONTRIBUTING.md)
- [X] My code matches the project’s coding style (`npm run lint`)
- [ ] My change introduces changes to the documentation
- [ ] I’ve updated documentation where needed
- [ ] I’ve added tests covering new behavior
- [X] All existing and new tests pass

### Related Issues

<!-- Reference related issues or discussions here -->
 - Closes  #21 