### PR TITLE
docs(contributing): add 'How to Find Something to Contribute' section

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,6 +22,10 @@ We’ll check the open issues, review them, and let you know what to do next. Be
 
 We might not reply right away, but we’ll get back to you as soon as we can. If you don’t hear from us quickly, it doesn’t mean we’re ignoring you. We’ll respond as soon as possible.
 
+## How to Find Something to Contribute
+
+Not sure where to start? See the [WAYS_TO_CONTRIBUTE.md](https://github.com/lovit-dev/lovit/blob/main/.github/WAYS_TO_CONTRIBUTE.md) guide for tips on finding tasks and getting involved.
+
 ## Labels
 
 Our bug tracker uses several labels to help organize and identify issues. Here's what they mean:


### PR DESCRIPTION
  Summary

  This pull request adds a new section, "How to Find Something to Contribute," to the CONTRIBUTING.md file. This section provides a direct link to the WAYS_TO_CONTRIBUTE.md guide, making it easier for new contributors to find relevant tasks and get involved in the project.

 Motivation

  This change is necessary to improve the onboarding experience for new contributors. By providing a clear and accessible pointer on how to find issues to work on, we lower the barrier to
  entry and encourage more community participation. This directly addresses the request made in issue #19.

  Change Type

  <!-- Indicate the type of changes this pull request introduces. Select all that apply by marking the boxes with an x. -->

   - [ ]  Bug fix (non-breaking fix for an issue)
   - [ ] ✨ Feature (non-breaking addition)
   - [ ]  Refactor (non-breaking improvements, no behavior change)
   - [ ]  Breaking change (fix or feature that would change existing functionality)

  (Note: This is a documentation update, which is not listed. No option has been selected.)

  Checklist

  <!-- Make sure to complete these before requesting a review -->

   - [x] I’ve read the [Contributing Guidelines (https://github.com/lovit-dev/lovit/blob/main/.github/CONTRIBUTING.md)
   - [x] My code matches the project’s coding style (npm run lint)
   - [x] My change introduces changes to the documentation
   - [x] I’ve updated documentation where needed
   - [ ] I’ve added tests covering new behavior
   - [ ] All existing and new tests pass

  Related Issues

  Closes #19