### PR TITLE
refactor: remove unnecessary export of Heading type

### DIFF
--- a/site/src/hooks/useHeadings.ts
+++ b/site/src/hooks/useHeadings.ts
@@ -5,15 +5,15 @@ const HEADING_H2 = 'H2';
 const HEADING_H3 = 'H3';
 const HEADING_DEFAULT_TITLE = 'Unknown';
 
-export interface HeadingItem {
-  id: string;
-  title: string;
-}
-
 interface Heading {
   id: string;
   title: string;
   items: HeadingItem[];
+}
+
+export interface HeadingItem {
+  id: string;
+  title: string;
 }
 
 export const useHeadings = () => {

--- a/site/src/hooks/useHeadings.ts
+++ b/site/src/hooks/useHeadings.ts
@@ -10,7 +10,7 @@ export interface HeadingItem {
   title: string;
 }
 
-export interface Heading {
+interface Heading {
   id: string;
   title: string;
   items: HeadingItem[];


### PR DESCRIPTION
### Safely Removed "export" keyword from Heading Interface 

- Closes #32 